### PR TITLE
Debug webpage not displaying after deployment

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "name": "psgundla-portfolio",
   "compatibility_date": "2025-12-11",
+  "pages_build_output_dir": "./dist",
   "assets": {
     "directory": "./dist",
     "html_handling": "auto-trailing-slash",


### PR DESCRIPTION
- Add pages_build_output_dir field to wrangler.jsonc
- This resolves the 522 timeout error by properly configuring the build output directory